### PR TITLE
Feat: 데이터 모델 생성 및 스크립트 작성 kan 55

### DIFF
--- a/src/models/current_history.ts
+++ b/src/models/current_history.ts
@@ -1,0 +1,64 @@
+import { Model, Table, Column, DataType, Index, Sequelize, ForeignKey, BelongsTo } from "sequelize-typescript";
+import { Portfolio } from "./portfolio";
+import { Account } from "./account";
+import { User } from "./user";
+
+export interface current_historyAttributes {
+  trading_id: number;
+  portfolio_id: number;
+  account_id: number;
+  uid?: number;
+  name?: string;
+  sll_buy_dvsn_cd?: string;
+  tot_ccld_qty?: string;
+  tot_ccld_amt?: string;
+  avg_prvs?: string;
+  trade_dt?: Date;
+}
+
+@Table({ tableName: "current_history", timestamps: false })
+export class Current_history
+  extends Model<current_historyAttributes, current_historyAttributes>
+  implements current_historyAttributes
+{
+  @Column({ primaryKey: true, type: DataType.BIGINT })
+  @Index({ name: "PRIMARY", using: "BTREE", order: "ASC", unique: true })
+  trading_id!: number;
+
+  @ForeignKey(() => Portfolio)
+  @Column({ type: DataType.BIGINT })
+  @Index({ name: "FK_portfolio_TO_current_history_1", using: "BTREE", order: "ASC", unique: false })
+  portfolio_id!: number;
+
+  @ForeignKey(() => Account)
+  @Column({ type: DataType.BIGINT })
+  account_id!: number;
+
+  @ForeignKey(() => User)
+  @Column({ type: DataType.BIGINT })
+  uid?: number;
+
+  @Column({ allowNull: true, type: DataType.STRING(30) })
+  name?: string;
+
+  @Column({ allowNull: true, type: DataType.STRING(30) })
+  sll_buy_dvsn_cd?: string;
+
+  @Column({ allowNull: true, type: DataType.STRING(30) })
+  tot_ccld_qty?: string;
+
+  @Column({ allowNull: true, type: DataType.STRING(30) })
+  tot_ccld_amt?: string;
+
+  @Column({ allowNull: true, type: DataType.STRING(30) })
+  avg_prvs?: string;
+
+  @Column({ allowNull: true, type: DataType.DATE })
+  trade_dt?: Date;
+
+  @BelongsTo(() => Portfolio)
+  portfolio!: Portfolio;
+
+  @BelongsTo(() => Account)
+  account!: Account;
+}

--- a/src/models/current_holding.ts
+++ b/src/models/current_holding.ts
@@ -22,7 +22,7 @@ export interface CurrentHoldingAttributes {
   tableName: "current_holding",
   timestamps: true,
 })
-export class CurrentHolding extends Model<CurrentHolding> {
+export class Current_holding extends Model<Current_holding, Current_holding> implements Current_holding {
   @PrimaryKey
   @Column({ type: DataType.BIGINT })
   holding_id!: number;

--- a/src/models/current_holding.ts
+++ b/src/models/current_holding.ts
@@ -1,0 +1,71 @@
+import { Model, Table, Column, DataType, PrimaryKey, ForeignKey, BelongsTo } from "sequelize-typescript";
+import { Portfolio } from "./portfolio";
+import { Account } from "./account";
+import { User } from "./user";
+
+export interface CurrentHoldingAttributes {
+  holding_id?: number;
+  portfolio_id: number;
+  account_id: number;
+  uid?: number;
+  name: string;
+  hldg_qty: string;
+  pchs_amt: string;
+  evlu_amt: string;
+  evlu_pfls_amt: string;
+  evlu_pfls_rt: string;
+  std_idst_clsf_cd_name: string;
+  closing_price: string;
+}
+
+@Table({
+  tableName: "current_holding",
+  timestamps: true,
+})
+export class CurrentHolding extends Model<CurrentHolding> {
+  @PrimaryKey
+  @Column({ type: DataType.BIGINT })
+  holding_id!: number;
+
+  @ForeignKey(() => Portfolio)
+  @Column({ type: DataType.BIGINT })
+  portfolio_id!: number;
+
+  @ForeignKey(() => Account)
+  @Column({ type: DataType.BIGINT })
+  account_id!: number;
+
+  @ForeignKey(() => User)
+  @Column({ type: DataType.BIGINT })
+  uid?: number;
+
+  @Column({ type: DataType.STRING(255) })
+  name!: string;
+
+  @Column({ type: DataType.STRING(30) })
+  hldg_qty!: string; // 보유 수량
+
+  @Column({ type: DataType.STRING(30) })
+  pchs_amt!: string; // 매입 금액
+
+  @Column({ type: DataType.STRING(30) })
+  evlu_amt!: string; // 평가 금액
+
+  @Column({ type: DataType.STRING(30) })
+  evlu_pfls_amt!: string; // 평가 손익
+
+  @Column({ type: DataType.STRING(30) })
+  evlu_pfls_rt!: string; // 평가 손익률
+
+  @Column({ type: DataType.STRING })
+  std_idst_clsf_cd_name!: string; // 표준 분류 코드명
+
+  @Column({ type: DataType.STRING(255) })
+  closing_price!: string; // 종가
+
+  @BelongsTo(() => Portfolio)
+  portfolio!: Portfolio;
+
+  @BelongsTo(() => Account)
+  account!: Account;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -13,6 +13,8 @@ import { Stock } from "./stock";
 import { Sub_portfolio } from "./sub_portfolio";
 import { Trading_history } from "./trading_history";
 import { Stock_history } from "./stock_history";
+import { Current_history } from "./current_history";
+import { Current_holding } from "./current_holding";
 
 export interface DB {
   sequelize: Sequelize;
@@ -41,6 +43,8 @@ sequelize.addModels([
   Sub_portfolio,
   Trading_history,
   Stock_history,
+  Current_history,
+  Current_holding,
 ]);
 
 export const initializeDatabase = async () => {

--- a/src/utils/extract_new_models.ts
+++ b/src/utils/extract_new_models.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+
+const backupDir = path.resolve(__dirname, "../models_backup");
+const newDir = path.resolve(__dirname, "../models");
+const outputDir = path.resolve(__dirname, "../new_models");
+
+const getFiles = (dir: string): string[] => {
+  return fs.readdirSync(dir).filter((file) => fs.lstatSync(path.join(dir, file)).isFile());
+};
+
+const backupFiles = getFiles(backupDir);
+const newFiles = getFiles(newDir);
+
+const newModels = newFiles.filter((file) => !backupFiles.includes(file));
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir);
+}
+
+newModels.forEach((file) => {
+  const srcPath = path.join(newDir, file);
+  const destPath = path.join(outputDir, file);
+
+  try {
+    fs.copyFileSync(srcPath, destPath);
+    console.log(`New model file copied: ${file}`);
+  } catch (error) {
+    console.error(`Error copying file ${file}:`, error);
+  }
+});


### PR DESCRIPTION
- 2종류의 새로운 데이터 모델 생성
- 기존 모델 백업 후, 새 모델로 파일 생성 시 비교를 통해 새 모델만 추출하기 위한 스크립트
  - 새롭게 데이터 모델을 추가했을 때, sql스크립트를 통해 파일을 작성해주는 라이브러리를 사용하게 되면 전체적으로 모든 파일이 다시 새로 생김 => 이러한 이슈를 해결하기 위해 스크립트 생성
<img width="1125" alt="스크린샷 2024-06-25 오전 2 48 05" src="https://github.com/PDA4-TEAM7/pda4-team7-back/assets/39377091/b20e106a-8d20-4e75-b436-a052cd91ff3d">
