### PR TITLE
Feat: 최근 거래 내역 테이블에 채워넣기

### DIFF
--- a/src/controllers/recency.ts
+++ b/src/controllers/recency.ts
@@ -1,9 +1,18 @@
 import { Request, Response } from "express";
-import UpdateRecencyHoldingAPI from "../services/updateRecencyHoldingAPI";
+import { UpdateRecencyHoldingAPI } from "../services/updateRecencyHoldingAPI";
 export const updateAllHoldings = async (req: Request, res: Response) => {
   try {
     await UpdateRecencyHoldingAPI.updateAllHoldings();
     res.status(200).json("최근 거래 내역:current_holding 업데이트 완료");
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const updateAllHistory = async (req: Request, res: Response) => {
+  try {
+    await UpdateRecencyHoldingAPI.updateAllHistory();
+    res.status(200).json("최근 거래 내역:updateAllHistory 업데이트 완료");
   } catch (error) {
     console.log(error);
   }

--- a/src/routes/recency.ts
+++ b/src/routes/recency.ts
@@ -1,6 +1,7 @@
 import express from "express";
-import { updateAllHoldings } from "../controllers/recency";
+import { updateAllHoldings, updateAllHistory } from "../controllers/recency";
 
 export default (router: express.Router) => {
   router.get("/recency/updateAllHoldings", updateAllHoldings);
+  router.get("/recency/updateAllHistory", updateAllHistory);
 };

--- a/src/services/apis/stockAccountAPI.ts
+++ b/src/services/apis/stockAccountAPI.ts
@@ -1,3 +1,4 @@
+import { formatYYMMDD } from "../../utils/time";
 import { HantuBaseApi } from "./hantuBaseAPI";
 const { HANTU_TR_ID_M_TRADING, HANTU_TR_ID_M } = process.env;
 const CANO = ""; //DUMMY: db account
@@ -60,12 +61,58 @@ export interface IAccountInquireBalance {
     asst_icdc_erng_rt: string;
   };
 }
-const formatDate = (date: Date) => {
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, "0"); // 월은 0부터 시작하므로 1을 더하고, 두 자리로 맞춤
-  const day = date.getDate().toString().padStart(2, "0"); // 일을 두 자리로 맞춤
-  return `${year}${month}${day}`;
-};
+// 일자별 거래내역 output1에 대한 응답
+export interface ITradingData {
+  ord_dt: string;
+  ord_gno_brno: string;
+  odno: string;
+  orgn_odno: string;
+  ord_dvsn_name: string;
+  sll_buy_dvsn_cd: string;
+  sll_buy_dvsn_cd_name: string;
+  pdno: string;
+  prdt_name: string;
+  ord_qty: string;
+  ord_unpr: string;
+  ord_tmd: string;
+  tot_ccld_qty: string;
+  avg_prvs: string;
+  cncl_yn: string;
+  tot_ccld_amt: string;
+  loan_dt: string;
+  ordr_empno: string;
+  ord_dvsn_cd: string;
+  cncl_cfrm_qty: string;
+  rmn_qty: string;
+  rjct_qty: string;
+  ccld_cndt_name: string;
+  inqr_ip_addr: string;
+  cpbc_ordp_ord_rcit_dvsn_cd: string;
+  cpbc_ordp_infm_mthd_dvsn_cd: string;
+  infm_tmd: string;
+  ctac_tlno: string;
+  prdt_type_cd: string;
+  excg_dvsn_cd: string;
+  cpbc_ordp_mtrl_dvsn_cd: string;
+  ord_orgno: string;
+  rsvn_ord_end_dt: string;
+}
+// 일자별 거래내역 전체에 대한 응답
+export interface ITradingResponse {
+  ctx_area_fk100: string;
+  ctx_area_nk100: string;
+  output1: ITradingData[];
+  output2: {
+    tot_ord_qty: string;
+    tot_ccld_qty: string;
+    tot_ccld_amt: string;
+    prsm_tlex_smtl: string;
+    pchs_avg_pric: string;
+  };
+  rt_cd: string;
+  msg_cd: string;
+  msg1: string;
+}
 export class StockAccountApi extends HantuBaseApi {
   async inquireBalance(cano: string) {
     const resp = await this.fetcher.get(
@@ -81,9 +128,9 @@ export class StockAccountApi extends HantuBaseApi {
     let CTX_AREA_FK100 = ""; //최초시 공란, 그 이후 데이터는 이전 조회 Ouput의 CTX_AREA_FK100 값
     let CTX_AREA_NK100 = ""; //최초시 공란, 그 이후 데이터는 이전 조회 Ouput의 CTX_AREA_NK100 값
     const currentDate = new Date();
-    const INQR_STRT_DT = formatDate(currentDate); // 조회 시작날짜
+    const INQR_STRT_DT = formatYYMMDD(currentDate); // 조회 시작날짜
     currentDate.setMonth(currentDate.getMonth() - 3);
-    const INQR_END_DT = formatDate(currentDate); // 조회 종료날짜
+    const INQR_END_DT = formatYYMMDD(currentDate); // 조회 종료날짜
     const SLL_BUY_DVSN_CD = "00"; //매수매도 구분 00전체 01매도 02매수
     const INQR_DVSN = "00"; //조회구분 00역순 01정순
     const INQR_DVSN_3 = "00"; //00전체 01 현금
@@ -117,6 +164,45 @@ export class StockAccountApi extends HantuBaseApi {
       }
     } catch (error) {
       console.log(error);
+    }
+
+    return tradingDatas;
+  }
+
+  async inquireSingleDayCCLD(cano: string): Promise<ITradingResponse[]> {
+    let CTX_AREA_FK100 = ""; // 최초시 공란
+    let CTX_AREA_NK100 = ""; // 최초시 공란
+    const currentDate = new Date();
+    const INQR_STRT_DT = formatYYMMDD(currentDate); // 조회할 단일 날짜
+    const INQR_END_DT = INQR_STRT_DT; // 동일 날짜로 설정
+    const SLL_BUY_DVSN_CD = "00"; // 매수매도 구분 코드: 00전체
+    const INQR_DVSN = "00"; // 조회구분: 00역순
+    const INQR_DVSN_3 = "00"; // 00전체 01 현금
+
+    let tradingDatas: ITradingResponse[] = [];
+
+    const getTranding = async (nk: string) => {
+      const resp = await this.fetcher.get<ITradingResponse>(
+        `/uapi/domestic-stock/v1/trading/inquire-daily-ccld?CANO=${cano}&ACNT_PRDT_CD=${ACNT_PRDT_CD}&INQR_STRT_DT=${INQR_STRT_DT}&INQR_END_DT=${INQR_END_DT}&SLL_BUY_DVSN_CD=${SLL_BUY_DVSN_CD}&INQR_DVSN=${INQR_DVSN}&PDNO=&CCLD_DVSN=${"01"}&ORD_GNO_BRNO=&ODNO=&INQR_DVSN_3=${INQR_DVSN_3}&INQR_DVSN_1=&CTX_AREA_FK100=${CTX_AREA_FK100}&CTX_AREA_NK100=${nk}&AFHR_FLPR_YN=&OFL_YN=N&UNPR_DVSN=01&FUND_STTL_ICLD_YN=N&FNCG_AMT_AUTO_RDPT_YN=N&PRCS_DVSN=01`,
+        { headers: { tr_id: HANTU_TR_ID_M_TRADING } }
+      );
+      console.log("거래내역 : ", resp.data.output1);
+      console.log("거래output2:", resp.data.output2);
+      console.log("message : ", resp.data.msg1);
+      console.log("nk : ", resp.data.ctx_area_nk100);
+      CTX_AREA_FK100 = resp.data.ctx_area_fk100;
+      CTX_AREA_NK100 = resp.data.ctx_area_nk100;
+      tradingDatas.push(resp.data);
+      if (resp.data.ctx_area_nk100.trim()) {
+        await getTranding(resp.data.ctx_area_nk100);
+      }
+    };
+
+    try {
+      await getTranding(CTX_AREA_NK100);
+    } catch (error) {
+      console.error("에러 발생: ", error);
+      throw new Error(`API 호출 중 에러가 발생했습니다: ${error}`);
     }
 
     return tradingDatas;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -22,3 +22,10 @@ export const setDateByOrd = (ord_dt: string, ord_tmd: string): Date => {
 
   return dateTime;
 };
+
+export const formatYYMMDD = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0"); // 월은 0부터 시작하므로 1을 더하고, 두 자리로 맞춤
+  const day = date.getDate().toString().padStart(2, "0"); // 일을 두 자리로 맞춤
+  return `${year}${month}${day}`;
+};


### PR DESCRIPTION
- 포트폴리오 구독한 사람들의 최근 투자 내역을 저장하는 API작성
- 현재는 오늘 기준이지만, 어제 기준으로 바꿔야함
- 3시 30분에 한 번씩 해야하며, 이전 테이블에 있던 기록은 날려야함 


<img width="754" alt="스크린샷 2024-06-25 오후 3 05 20" src="https://github.com/PDA4-TEAM7/pda4-team7-back/assets/39377091/c90e4e22-5012-4f4e-a7bd-d7747fce6d4f">
