### PR TITLE
Feat CronJob

### DIFF
--- a/src/controllers/account.ts
+++ b/src/controllers/account.ts
@@ -178,3 +178,8 @@ export const deleteAccount = async (req: Request, res: Response) => {
     return res.sendStatus(500); // 내부 서버 오류
   }
 };
+
+//계정 전부 찾기
+export const getAllAccounts = async () => {
+  return await Account.findAll();
+};

--- a/src/services/newUpdateAPI.ts
+++ b/src/services/newUpdateAPI.ts
@@ -1,0 +1,72 @@
+import { Account } from "../models/account";
+import { StockAccountApi } from "./apis/stockAccountAPI";
+import { Stock_in_account } from "../models/stock_in_account";
+import { Stock } from "../models/stock";
+import { Trading_history } from "../models/trading_history";
+import { setDateByOrd } from "../utils/time";
+
+export const updateStockInAccount = async (account: Account) => {
+  if (!account.account_number) {
+    console.error(`Account number is missing for account ID: ${account.account_id}`);
+    return;
+  }
+
+  try {
+    const stockAccountApi = new StockAccountApi(account.app_key, account.app_secret, account.access_token);
+    const inquirePriceRes = await stockAccountApi.inquireBalance(account.account_number);
+    const stocks = inquirePriceRes.output1;
+
+    for (const data of stocks) {
+      const stock = await Stock.findOne({ where: { code: data.pdno } });
+      if (stock) {
+        await Stock_in_account.upsert({
+          account_id: account.account_id,
+          stock_id: stock.stock_id,
+          market_id: 1,
+          hldg_qty: data.hldg_qty,
+          pchs_amt: data.pchs_amt,
+          evlu_amt: data.evlu_amt,
+          evlu_pfls_amt: data.evlu_pfls_amt,
+        });
+      }
+    }
+
+    const accountAsset = inquirePriceRes.output2[0];
+    account.pchs_amt_smtl_amt = accountAsset.pchs_amt_smtl_amt;
+    account.evlu_amt_smtl_amt = accountAsset.evlu_amt_smtl_amt;
+    account.evlu_pfls_smtl_amt = accountAsset.evlu_pfls_smtl_amt;
+    await account.save();
+  } catch (error) {
+    console.error(`Failed to update stock in account for account ${account.account_number}`, error);
+  }
+};
+
+export const updateTradingHistory = async (account: Account) => {
+  if (!account.account_number) {
+    console.error(`Account number is missing for account ID: ${account.account_id}`);
+    return;
+  }
+
+  try {
+    const stockAccountApi = new StockAccountApi(account.app_key, account.app_secret, account.access_token);
+    const tradingHistoryRes = await stockAccountApi.inquireDailyCCLD(account.account_number);
+
+    for (const data of tradingHistoryRes) {
+      const stock = await Stock.findOne({ where: { code: data.pdno } });
+      if (stock) {
+        await Trading_history.create({
+          account_id: account.account_id,
+          stock_id: stock.stock_id,
+          sll_buy_dvsn_cd: data.sll_buy_dvsn_cd,
+          trade_dt: setDateByOrd(data.ord_dt, data.ord_tmd),
+          tot_ccld_qty: data.tot_ccld_qty,
+          tot_ccld_amt: data.tot_ccld_amt,
+          evlu_pfls_amt: data.evlu_pfls_amt || null,
+          evlu_pfls_rt: data.evlu_pfls_rt || null,
+        });
+      }
+    }
+  } catch (error) {
+    console.error(`Failed to update trading history for account ${account.account_number}`, error);
+  }
+};


### PR DESCRIPTION
Feat. recencyholdings와 recencyhistory model에서 사용하기 위해 두 값 업데이트하는 함수, cronjob 을 영업일 기준(월-금)동안만 돌아가도록 설정
Feat. stock_in_acount, trading_history를 장 마감 후, 영업일(월-금)동안만 업데이트 시키도록 처리. trading_history는 전날 기준 data만 담아놓기 때문에 update할때마다 table을 비우는 식으로 처리
Feat.모든account에 대해 cronjob실행 위해 모든 account가져오는 함수 생성